### PR TITLE
Use 170bp as a better estimate for wastewater than 120bp

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -342,7 +342,7 @@ standard deviation of the log.
 <tr><td colspan=4 class=note>When sequencing wastewater the nucleic acid
 fragments tend to be pretty torn up by the hostile environment, making
 it difficult to get much value from long-read sequencing.  If this box
-is checked we assume that sequencing reads won't be longer than 120bp
+is checked we assume that sequencing reads won't be longer than 170bp
 even if you're using a sequencing machine capable of producing longer
 ones when given good material.
 <tr><td>Sample population (people):
@@ -562,7 +562,7 @@ function simulate_one() {
   read_length_usable = Math.min(read_length_usable, bp_genome_length)
 
   if (low_quality.checked) {
-    read_length_usable = Math.min(read_length_usable, 120);
+    read_length_usable = Math.min(read_length_usable, 170);
   }
 
   // The detection model here is that there is some small section of


### PR DESCRIPTION
I was trying to debug why I was seeing surprising results with the simulator, and I noticed that we've been using 120bp as an estimate for how short fragments tend to be when sequencing wastewater.  This is too conservative: looking at SARS-CoV-2 in the MU data I see a mean per-base coverage of 5.83 per 1000 reads (when excluding the amplicon spike contamination) over a 29,225bp genome, and 5.83 / 1000 * 29225 = 170.